### PR TITLE
add missing math builtins

### DIFF
--- a/syntax/zig.vim
+++ b/syntax/zig.vim
@@ -43,6 +43,7 @@ syn match zigBuiltinFn "\v\@(setGlobalLinkage|setGlobalSection|shlExact|This|has
 syn match zigBuiltinFn "\v\@(shlWithOverflow|shrExact|sizeOf|sqrt|byteSwap|subWithOverflow|intCast|floatCast|intToFloat|floatToInt|boolToInt|errSetCast)>"
 syn match zigBuiltinFn "\v\@(truncate|typeId|typeInfo|typeName|typeOf|atomicRmw|bytesToSlice|sliceToBytes)>"
 syn match zigBuiltinFn "\v\@(intToError|errorToInt|intToEnum|enumToInt|setAlignStack|frame|Frame|frameSize|bitReverse|Vector)>"
+syn match zigBuiltinFn "\v\@(sin|cos|exp|exp2|ln|log2|log10|fabs|floor|ceil|trunc|round)>"
 
 syn match zigDecNumber display "\<[0-9]\+\%(.[0-9]\+\)\=\%([eE][+-]\?[0-9]\+\)\="
 syn match zigHexNumber display "\<0x[a-fA-F0-9]\+\%([a-fA-F0-9]\+\%([pP][+-]\?[0-9]\+\)\?\)\="


### PR DESCRIPTION
add `@sin`, `@cos`, `@exp`, `@exp2`, `@ln`, `@log2`, `@log10`, `@fabs`, `@floor`, `@ceil`, `@trunc` and `@round`