### PR TITLE
use setlocal instead of set for indentation settings

### DIFF
--- a/ftplugin/zig.vim
+++ b/ftplugin/zig.vim
@@ -5,9 +5,9 @@ endif
 
 let b:did_ftplugin = 1
 
-set expandtab
-set tabstop=4
-set shiftwidth=4
+setlocal expandtab
+setlocal tabstop=4
+setlocal shiftwidth=4
 
 setlocal suffixesadd=.zig
 setlocal commentstring=//\ %s


### PR DESCRIPTION
this fixes https://github.com/ziglang/zig.vim/issues/12