### PR TITLE
Support previous-line doc comments

### DIFF
--- a/syntax/zig.vim
+++ b/syntax/zig.vim
@@ -58,7 +58,7 @@ syn match zigCharacter /'\([^\\]\|\\\(.\|x\x\{2}\|u\x\{4}\|U\x\{6}\)\)'/ contain
 syn region zigBlock start="{" end="}" transparent fold
 
 syn region zigCommentLine start="//" end="$" contains=zigTodo,@Spell
-syn region zigCommentLineDoc start="////\@!" end="$" contains=zigTodo,@Spell
+syn region zigCommentLineDoc start="//[/|!]/\@!" end="$" contains=zigTodo,@Spell
 
 " TODO: match only the first '\\' within the zigMultilineString as zigMultilineStringPrefix
 syn match zigMultilineStringPrefix display contained /c\?\\\\/

--- a/syntax/zig.vim
+++ b/syntax/zig.vim
@@ -58,7 +58,7 @@ syn match zigCharacter /'\([^\\]\|\\\(.\|x\x\{2}\|u\x\{4}\|U\x\{6}\)\)'/ contain
 syn region zigBlock start="{" end="}" transparent fold
 
 syn region zigCommentLine start="//" end="$" contains=zigTodo,@Spell
-syn region zigCommentLineDoc start="//[/|!]/\@!" end="$" contains=zigTodo,@Spell
+syn region zigCommentLineDoc start="//[/!]/\@!" end="$" contains=zigTodo,@Spell
 
 " TODO: match only the first '\\' within the zigMultilineString as zigMultilineStringPrefix
 syn match zigMultilineStringPrefix display contained /c\?\\\\/


### PR DESCRIPTION
This adds support for `//!` previous-line doc comments. Like for `zig-mode` for Emacs: https://github.com/ziglang/zig-mode/pull/28