### PR TITLE
Add ~ operator

### DIFF
--- a/syntax/zig.vim
+++ b/syntax/zig.vim
@@ -24,8 +24,8 @@ syn keyword zigBoolean true false
 
 syn match zigType "\v<[iu][1-9]\d*>"
 
-syn match zigOperator display "\%(+%\?\|-%\?\|/\|*%\?\|=\|\^\|&\|?\||\|!\|>\|<\|%\|<<%\?\|>>\)=\?"
-syn match zigArrowCharacter display "->"
+syn match zigOperator display "\V\[-+/*=^&?|!><%~]"
+syn match zigArrowCharacter display "\V->"
 
 syn match zigBuiltinFn "\v\@(addWithOverflow|as|atomicLoad|atomicStore|bitCast|breakpoint)>"
 syn match zigBuiltinFn "\v\@(alignCast|alignOf|cDefine|cImport|cInclude)>"


### PR DESCRIPTION
This adds `~`, which was previously not highlighted, and simplifies the operator grammar.

Without this change, `+%=` was highlighted because it matched the regex for operators.  With this change, it's highlighted because `+`, `%`, and `=` each match.

I can think of two reasons to prefer something similar to the current regex over the simplified one in this PR:
 - It would make it easier to have text objects for a whole operator, allowing things like `dao` to delete the current operator.  I don't think this would be useful at all, though, and it would require significant more work to do.
 - Perhaps the intention is to not highlight "bad" operators, like `%+`.  However, the current regex highlights this, as `%` is an operator, and then `+` is another operator.  Not highlighting bad operators would require more familiarity with both Vim regexes and Zig's lexical grammar than I have.

As things currently are, though, I think the simpler regex is better.

I also added `\V` to a couple regexes, so that they won't be affected by a user's custom setting for `'magic'`.