### PR TITLE
Some improvements for the ftplugin

### DIFF
--- a/ftplugin/zig.vim
+++ b/ftplugin/zig.vim
@@ -1,20 +1,30 @@
 " Only do this when not done yet for this buffer
-if (exists("b:did_ftplugin"))
+if exists("b:did_ftplugin")
   finish
 endif
 
 let b:did_ftplugin = 1
 
+let s:cpo_orig = &cpo
+set cpo&vim
+
+" Recomended code style, no tabs and 4-space indentation
 setlocal expandtab
-setlocal tabstop=4
+setlocal tabstop=8
+setlocal softtabstop=4
 setlocal shiftwidth=4
 
-setlocal suffixesadd=.zig
-setlocal suffixesadd=.zir
-setlocal commentstring=//\ %s
+setlocal formatoptions-=t formatoptions+=croql
+
+setlocal suffixesadd=.zig,.zir
 setlocal makeprg=zig\ build
 
-if (has("comments"))
-    set comments=:///,://,:\\\\
-    set formatoptions=tcqor
+if has("comments")
+    setlocal comments=:///,://!,://,:\\\\
+    setlocal commentstring=//\ %s
 endif
+
+let b:undo_ftplugin = "setl et< ts< sts< sw< fo< sua< mp< com< cms<"
+
+let &cpo = s:cpo_orig
+unlet s:cpo_orig


### PR DESCRIPTION
* Avoid setting `tabstop` to 4, use the correct set of options to make
  sure the indentation used 4 spaces (See this [rust.vim](https://github.com/rust-lang/rust.vim/commit/46bfb18bbced96387c6f7981c039fcdc2d37fee7) commit for more info)
* Use `setlocal` instead of `set`, the settings should apply to the
  current buffer only
* Add a way to undo the ftplugin effects
* Avoid overwriting `suffixesadd`
* Be kind and keep the user formatoptions in mind, use some saner
  defaults (same as C and C-like languages)
* Recognize doc-comments