### PR TITLE
Setup vim's include-search for Zig

### DIFF
--- a/ftplugin/zig.vim
+++ b/ftplugin/zig.vim
@@ -24,6 +24,16 @@ if has("comments")
     setlocal commentstring=//\ %s
 endif
 
+if has('find_in_path')
+	let &l:includeexpr='substitute(v:fname, "^([^.])$", "\1.zig", "")'
+	let &l:include='\v(\@import>|\@cInclude>|^\s*\#\s*include)'
+	let &l:define='\v(<fn>|<const>|<var>|^\s*\#\s*define)'
+endif
+
+if has('eval')
+	execute 'setlocal path+=' . json_decode(system('zig env'))['std_dir']
+endif
+
 let b:undo_ftplugin = "setl et< ts< sts< sw< fo< sua< mp< com< cms<"
 
 let &cpo = s:cpo_orig


### PR DESCRIPTION
Vim can search for definitions inside of `#include`d files in C source files with the keybindings [i for first occurrence, [d for first definition, and so on.
`:h include-search` for more detail.
Notably, &include and &define still keep their old C values, since Zig will often interfaces with C.