### PR TITLE
l:path respects g:path if original l:path is empty

### DIFF
--- a/ftplugin/zig.vim
+++ b/ftplugin/zig.vim
@@ -34,7 +34,7 @@ let &l:define='\v(<fn>|<const>|<var>|^\s*\#\s*define)'
 if exists("*json_decode") && executable('zig')
     silent let s:env = system('zig env')
     if v:shell_error == 0
-        let &l:path=json_decode(s:env)['std_dir'] . ',' . &l:path
+        let &l:path=json_decode(s:env)['std_dir'] . ',' . [&l:path, &g:path][empty(&l:path)]
     endif
     unlet! s:env
 endif


### PR DESCRIPTION
As per @LemonBoy's suggestion in #32 

> The slowness you're seeing is probably due to the zig env being called at startup, the define/include changes should not affect anything beside the use of [i and [d. I've noticed that the very first call to env, when all the files are hashed, takes a few seconds on my machine.

>This fixes the bug where path only includes the zig library, but fails to correctly append the C header files or the current working directory.

>That was intentional, if you want to implement the local/global fallback I'd suggest something like this:

        let old_path=[&l:path, &g:path][empty(&l:path)]
        let &l:path=json_decode(s:env)['std_dir'] . ',' . old_path