### PR TITLE
Simplify includeexpr

### DIFF
--- a/ftplugin/zig.vim
+++ b/ftplugin/zig.vim
@@ -25,7 +25,7 @@ if has('comments')
 endif
 
 if has('find_in_path')
-    let &l:includeexpr='substitute(v:fname, "^([^.])$", "\1.zig", "")'
+    let &l:includeexpr='substitute(v:fname, "^std$", "std.zig", "")'
     let &l:include='\v(\@import>|\@cInclude>|^\s*\#\s*include)'
 endif
 


### PR DESCRIPTION
The only time @include() doesn't specify a filename is when it is "std" or when loading another custom package.
We don't know where the custom package root is just with pure vim.