### PR TITLE
Use vim compilers instead of just setting makeprg

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,10 @@ This plugin enables automatic code formatting on save by default using
 ```
 let g:zig_fmt_autosave = 0
 ```
+
+The default compiler which gets used by `:make` (`:help :compiler` for details)
+is `zig_build` and it runs `zig build`.  The other options are:
+ * `:compiler zig_test` which runs `zig test` on the current file.
+ * `:compiler zig_build_exe` which runs `zig build-exe` on the current file.
+ * `:compiler zig` which requires that a subcommand is passed as an argument
+   and it runs on the current file.

--- a/compiler/zig.vim
+++ b/compiler/zig.vim
@@ -1,0 +1,28 @@
+" Vim compiler file
+" Compiler: Zig Compiler
+" For bugs, patches and license go to https://github.com/ziglang/zig.vim
+
+if exists("current_compiler")
+    finish
+endif
+let current_compiler = "zig"
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+if exists(":CompilerSet") != 2
+    command -nargs=* CompilerSet setlocal <args>
+endif
+
+" a subcommand must be provided for the this compiler (test, build-exe, etc)
+if has('patch-7.4.191')
+    CompilerSet makeprg=zig\ \$*\ \%:S
+else
+    CompilerSet makeprg=zig\ \$*\ \"%\"
+endif
+
+" TODO: improve errorformat as needed.
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+" vim: tabstop=8 shiftwidth=4 softtabstop=4 expandtab

--- a/compiler/zig_build.vim
+++ b/compiler/zig_build.vim
@@ -1,0 +1,28 @@
+" Vim compiler file
+" Compiler: Zig Compiler (zig build)
+
+if exists('current_compiler')
+  finish
+endif
+runtime compiler/zig.vim
+let current_compiler = 'zig_build'
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+
+if exists(':CompilerSet') != 2
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+if exists('g:zig_build_makeprg_params')
+	execute 'CompilerSet makeprg=zig\ build\ '.escape(g:zig_build_makeprg_params, ' \|"').'\ $*'
+else
+	CompilerSet makeprg=zig\ build\ $*
+endif
+
+" TODO: anything to add to errorformat for zig build specifically?
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+" vim: tabstop=8 shiftwidth=4 softtabstop=4 expandtab

--- a/compiler/zig_build_exe.vim
+++ b/compiler/zig_build_exe.vim
@@ -1,0 +1,26 @@
+" Vim compiler file
+" Compiler: Zig Compiler (zig build-exe)
+
+if exists('current_compiler')
+  finish
+endif
+runtime compiler/zig.vim
+let current_compiler = 'zig_build_exe'
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+
+if exists(':CompilerSet') != 2
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+if has('patch-7.4.191')
+  CompilerSet makeprg=zig\ build-exe\ \%:S\ \$* 
+else
+  CompilerSet makeprg=zig\ build-exe\ \"%\"\ \$* 
+endif
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+" vim: tabstop=8 shiftwidth=4 softtabstop=4 expandtab

--- a/compiler/zig_test.vim
+++ b/compiler/zig_test.vim
@@ -1,0 +1,26 @@
+" Vim compiler file
+" Compiler: Zig Compiler (zig test)
+
+if exists('current_compiler')
+  finish
+endif
+runtime compiler/zig.vim
+let current_compiler = 'zig_test'
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+
+if exists(':CompilerSet') != 2
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+if has('patch-7.4.191')
+  CompilerSet makeprg=zig\ test\ \%:S\ \$* 
+else
+  CompilerSet makeprg=zig\ test\ \"%\"\ \$* 
+endif
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+" vim: tabstop=8 shiftwidth=4 softtabstop=4 expandtab

--- a/ftplugin/zig.vim
+++ b/ftplugin/zig.vim
@@ -8,13 +8,7 @@ let b:did_ftplugin = 1
 let s:cpo_orig = &cpo
 set cpo&vim
 
-if get(b:, 'current_compiler', '') ==# ''
-    if strlen(findfile('build.zig', '.;')) > 0
-        compiler zig_build
-    else
-        compiler zig_build_exe
-    endif
-endif
+compiler zig_build
 
 " Match Zig builtin fns
 setlocal iskeyword+=@-@

--- a/ftplugin/zig.vim
+++ b/ftplugin/zig.vim
@@ -8,6 +8,14 @@ let b:did_ftplugin = 1
 let s:cpo_orig = &cpo
 set cpo&vim
 
+if get(b:, 'current_compiler', '') ==# ''
+    if strlen(findfile('build.zig', '.;')) > 0
+        compiler zig_build
+    else
+        compiler zig_build_exe
+    endif
+endif
+
 " Match Zig builtin fns
 setlocal iskeyword+=@-@
 
@@ -20,7 +28,6 @@ setlocal shiftwidth=4
 setlocal formatoptions-=t formatoptions+=croql
 
 setlocal suffixesadd=.zig,.zir
-setlocal makeprg=zig\ build
 
 if has('comments')
     setlocal comments=:///,://!,://,:\\\\


### PR DESCRIPTION
I think this is the "right" way of doing things as opposed to just setting makeprg. The options and compilers added here should be documented at some point. I would have added them to the docs, but there is no docs file. This keeps the same default of using `zig build` for make but it first checks if there is a build.zig file in cwd. If not it uses `zig build-exe`