### PR TITLE
change how the buffer content is replaced

### DIFF
--- a/autoload/zig/fmt.vim
+++ b/autoload/zig/fmt.vim
@@ -27,8 +27,8 @@ function! zig#fmt#Format() abort
     try | silent undojoin | catch | endtry
 
     " Replace the file content with the formatted version.
-    call deletebufline(current_buf, len(out), line('$'))
-    call setline(1, out)
+    call deletebufline(current_buf, 1, line('$'))
+    call setbufline(current_buf, 1, out)
 
     " No errors detected, close the loclist.
     call setloclist(0, [], 'r')


### PR DESCRIPTION
This prevents a bad behaviour when using zls with neovim.

Before, the content of the buffer was replaced without being deleted first: in neovim this causes the callback `on_lines` to be called _for each line_ being replaced.

This `on_lines` callback is used to notify LSP servers of changes to the document, so everytime a 2000 lines file is saved neovim would trigger 2000 calls to zls.

This can be seen in the lsp log from neovim:
```
[ DEBUG ] 2021-03-07T17:37:23+0100 ] /home/vincent/local/share/nvim/runtime/lua/vim/lsp.lua:816 ]	"on_lines bufnr: 1, changedtick: 5, firstline: 0, lastline: 1, new_lastline: 1, old_byte_size: 28, old_utf32_size: 28, old_utf16_size: 28"	{ 'const std = @import("std");' }
[ DEBUG ] 2021-03-07T17:37:23+0100 ] /home/vincent/local/share/nvim/runtime/lua/vim/lsp.lua:816 ]	"on_lines bufnr: 1, changedtick: 6, firstline: 1, lastline: 2, new_lastline: 2, old_byte_size: 48, old_utf32_size: 48, old_utf16_size: 48"	{ 'const build_options = @import("build_options");' }
[ DEBUG ] 2021-03-07T17:37:23+0100 ] /home/vincent/local/share/nvim/runtime/lua/vim/lsp.lua:816 ]	"on_lines bufnr: 1, changedtick: 7, firstline: 2, lastline: 3, new_lastline: 3, old_byte_size: 25, old_utf32_size: 25, old_utf16_size: 25"	{ "const debug = std.debug;" }
[ DEBUG ] 2021-03-07T17:37:23+0100 ] /home/vincent/local/share/nvim/runtime/lua/vim/lsp.lua:816 ]	"on_lines bufnr: 1, changedtick: 8, firstline: 3, lastline: 4, new_lastline: 4, old_byte_size: 19, old_utf32_size: 19, old_utf16_size: 19"	{ "const io = std.io;" }
[ DEBUG ] 2021-03-07T17:37:23+0100 ] /home/vincent/local/share/nvim/runtime/lua/vim/lsp.lua:816 ]	"on_lines bufnr: 1, changedtick: 9, firstline: 4, lastline: 5, new_lastline: 5, old_byte_size: 21, old_utf32_size: 21, old_utf16_size: 21"	{ "const mem = std.mem;" }
[ DEBUG ] 2021-03-07T17:37:23+0100 ] /home/vincent/local/share/nvim/runtime/lua/vim/lsp.lua:816 ]	"on_lines bufnr: 1, changedtick: 10, firstline: 5, lastline: 6, new_lastline: 6, old_byte_size: 29, old_utf32_size: 29, old_utf16_size: 29"	{ "const testing = std.testing;" }
```

When editing a 2000 lines file this makes neovim hang for a couple of seconds when saving the file, as well as generating more than 100MiB of LSP debug logs.

This commit fixes this by completely deleting the buffer before setting its content.

Now in the lsp log I get this:
```
[ DEBUG ] 2021-03-07T17:58:00+0100 ] /home/vincent/local/share/nvim/runtime/lua/vim/lsp.lua:816 ]	"on_lines bufnr: 1, changedtick: 4, firstline: 0, lastline: 1976, new_lastline: 0, old_byte_size: 67189, old_utf32_size: 67186, old_utf16_size: 67186"	{}
[ DEBUG ] 2021-03-07T17:58:00+0100 ] /home/vincent/local/share/nvim/runtime/lua/vim/lsp.lua:816 ]	"on_lines bufnr: 1, changedtick: 5, firstline: 0, lastline: 1, new_lastline: 1, old_byte_size: 1, old_utf32_size: 1, old_utf16_size: 1"	
[ DEBUG ] 2021-03-07T17:58:00+0100 ] /home/vincent/local/share/nvim/runtime/lua/vim/lsp.lua:816 ]	"on_lines bufnr: 1, changedtick: 6, firstline: 1, lastline: 1, new_lastline: 1976, old_byte_size: 0, old_utf32_size: 0, old_utf16_size: 0"	
```

It's not perfect because now there's a callback with everything deleted and another with the full content, but at least for me it solve the immediate problem of zls being unusable.

**Note**: I haven't tested this with vim yet