### PR TITLE
Minor fixes to fmt implementation

### DIFF
--- a/autoload/zig/fmt.vim
+++ b/autoload/zig/fmt.vim
@@ -8,11 +8,13 @@ function! zig#fmt#Format() abort
   " Save cursor position and many other things.
   let view = winsaveview()
 
-  let current_buf = bufnr('')
+  if !executable('zig')
+    echohl Error | echomsg "no zig binary found in PATH" | echohl None
+    return
+  endif
 
-  let bin_path = get(g:, 'zig_bin_path', 'zig')
-  let stderr_file = tempname()
-  let cmdline = printf('%s fmt --stdin 2> %s', bin_path, stderr_file)
+  let cmdline = 'zig fmt --stdin'
+  let current_buf = bufnr('')
 
   " The formatted code is output on stdout, the errors go on stderr.
   if exists('*systemlist')
@@ -38,7 +40,7 @@ function! zig#fmt#Format() abort
     call setloclist(0, [], 'r')
     lclose
   elseif get(g:, 'zig_fmt_parse_errors', 1)
-    let errors = s:parse_errors(expand('%'), readfile(stderr_file))
+    let errors = s:parse_errors(expand('%'), out)
 
     call setloclist(0, [], 'r', {
         \ 'title': 'Errors',
@@ -49,10 +51,8 @@ function! zig#fmt#Format() abort
     " Prevent the loclist from becoming too long.
     let win_height = min([max_win_height, len(errors)])
     " Open the loclist, but only if there's at least one error to show.
-    execute 'lwindow ' . win_height
+    execute 'silent! lwindow ' . win_height
   endif
-
-  call delete(stderr_file)
 
   call winrestview(view)
 


### PR DESCRIPTION
* Use zig binary in PATH (as done in the ftplugin)
* Avoid useless detour to a temporary file, system() merges stdin and
  stdout
* Avoid silly 'Press enter to continue' message when opening the loclist