### PR TITLE
set formatprg to 'zig fmt --stdin'

### DIFF
--- a/ftplugin/zig.vim
+++ b/ftplugin/zig.vim
@@ -46,7 +46,7 @@ endif
 let &l:formatprg = 'zig fmt --stdin'
 
 let b:undo_ftplugin =
-    \ 'setl isk< et< ts< sts< sw< fo< sua< mp< com< cms< inex< inc< pa<'
+    \ 'setl isk< et< ts< sts< sw< fo< sua< mp< com< cms< inex< inc< pa< fp<'
 
 let &cpo = s:cpo_orig
 unlet s:cpo_orig

--- a/ftplugin/zig.vim
+++ b/ftplugin/zig.vim
@@ -43,6 +43,8 @@ if exists("*json_decode") && executable('zig')
     unlet! s:env
 endif
 
+let &l:formatprg = 'zig fmt --stdin'
+
 let b:undo_ftplugin =
     \ 'setl isk< et< ts< sts< sw< fo< sua< mp< com< cms< inex< inc< pa<'
 


### PR DESCRIPTION
This supports vim's gq command to format code with 'zig fmt --stdin'.