### PR TITLE
Fixing indentation on empty brackets with trailing comma/colon (issue #42)

### DIFF
--- a/indent/zig.vim
+++ b/indent/zig.vim
@@ -49,19 +49,12 @@ function! GetZigIndent(lnum)
     "   },
     "   };
     " try treat them the same as a }
-    if prevLine =~ '\v^\s*},$'
-        if currentLine =~ '\v^\s*};$' || currentLine =~ '\v^\s*}$'
+    if prevLine =~ '\v^\s*}\s*[,;]\s*$'
+        if currentLine =~ '\v^\s*}\s*[,;]?\s*$'
             return indent(prevLineNum) - 4
         endif
         return indent(prevLineNum-1) - 4
     endif
-    if currentLine =~ '\v^\s*},$'
-        return indent(prevLineNum) - 4
-    endif
-    if currentLine =~ '\v^\s*};$'
-        return indent(prevLineNum) - 4
-    endif
-
 
     " cindent doesn't handle this case correctly:
     " switch (1): {


### PR DESCRIPTION
An attempt on fixing what https://github.com/ziglang/zig.vim/issues/42 reports.

I'm not yet sure if this fully fixes the issue. I'll be testing it more on the following days and will report any issue I find.