### PR TITLE
Indentation - fixing "lone" else lines

### DIFF
--- a/indent/zig.vim
+++ b/indent/zig.vim
@@ -45,6 +45,31 @@ function! GetZigIndent(lnum)
     let prevLineNum = prevnonblank(a:lnum-1)
     let prevLine = getline(prevLineNum)
 
+    " for lines that begin with an `else`:
+    if currentLine =~ '\v^\s*else>'
+        " TODO: explain the process
+        " FIXME: would this cause uneeded slowdowns?
+        let indentLimit = indent(prevLineNum)
+        let lineNum = prevLineNum
+        while 1
+            let lineNum = prevnonblank(lineNum-1)
+            if lineNum < 1
+                return -1
+            endif
+
+            let line = getline(lineNum)
+
+            let lineNumIndent = indent(lineNum)
+            if lineNumIndent < indentLimit
+                if line =~ '\v<if>'
+                    return lineNumIndent
+                endif
+
+                return -1
+            endif
+        endwhile
+    endif
+
     " for lines that look like
     "   },
     "   };


### PR DESCRIPTION
Currently, "lone" `else` lines don't seem to indent properly. I'm trying to fix that.
Current progress on this branch (you should be able to `=G` from the first line and have the same result):
```zig
{
    if (cond) branchA()
else branchB(); // not properly indented yet
}

{
    if (cond) branchA()
    else branchB();

    if (cond)
        if (foo)
            blk: {
                break :blk branchA();
            }
        else
            branchB();
    else
        branchB();

    const val = if (cond) branchA();
    else branchB();

    const val = if (cond)
        branchA();
    else
        branchB();

    const val = if (cond) blk: {
        break :blk branchA();
    }
    else blk: {
        break :blk branchB();
    }
}
```
Suggestions are appreciated!

Also, the method I'm doing uses a for loop - I'm not sure if that's very efficient so that might be a thing to be changed later.