### PR TITLE
Let the multiline string delimiter be a delimiter

### DIFF
--- a/syntax/zig.vim
+++ b/syntax/zig.vim
@@ -254,7 +254,7 @@ highlight default link zigStringDelimiter Delimiter
 highlight default link zigMultilineString String
 highlight default link zigMultilineStringContent String
 highlight default link zigMultilineStringPrefix String
-highlight default link zigMultilineStringDelimiter Ignore
+highlight default link zigMultilineStringDelimiter Delimiter
 highlight default link zigCharacterInvalid Error
 highlight default link zigCharacterInvalidUnicode zigCharacterInvalid
 highlight default link zigCharacter Character


### PR DESCRIPTION
I find the current behavior slightly confusing: while browsing Zig's
standard library, I found myself wondering how a certain chunk of code
could compile (it looked as if a raw JSON object was passed as argument
to a function), only to realize I was looking at a string, and that the
multiline string delimiter was hidden!

Also, quoting `:h hl-Ignore`:

    When using the Ignore group, you may also
    consider using the conceal mechanism.