### PR TITLE
Allow user to specify std dir

### DIFF
--- a/ftplugin/zig.vim
+++ b/ftplugin/zig.vim
@@ -35,12 +35,16 @@ endif
 
 let &l:define='\v(<fn>|<const>|<var>|^\s*\#\s*define)'
 
-if exists("*json_decode") && executable('zig')
+if !exists('g:zig_std_dir') && exists('*json_decode') && executable('zig')
     silent let s:env = system('zig env')
     if v:shell_error == 0
-        let &l:path=json_decode(s:env)['std_dir'] . ',' . &l:path
+        let g:zig_std_dir = json_decode(s:env)['std_dir']
     endif
     unlet! s:env
+endif
+
+if exists('g:zig_std_dir')
+    let &l:path = g:zig_std_dir . ',' . &l:path
 endif
 
 let b:undo_ftplugin =


### PR DESCRIPTION
Running 'zig env' adds a considerable amount of time to startup, and the
relevant result (the std directory) doesn't typically change often.
Allow users to manually specify the std dir through the `g:zig_std_dir`
global variable and fallback to calling 'zig env' only if this variable
doesn't exist.
