### PR TITLE
replace c_void with anyopaque

### DIFF
--- a/syntax/zig.vim
+++ b/syntax/zig.vim
@@ -43,7 +43,7 @@ let s:zig_syntax_keywords = {
     \ ,             "c_longlong"
     \ ,             "c_ulonglong"
     \ ,             "c_longdouble"
-    \ ,             "c_void"]
+    \ ,             "anyopaque"]
     \ , 'zigConstant': ["undefined"
     \ ,                 "unreachable"]
     \ , 'zigConditional': ["if"


### PR DESCRIPTION
With version 0.9.0, the keyword/type c_void was renamed anyopaque. this
commit fixes that in the syntax.