### PR TITLE
Do fmt and ast-check steps separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,20 @@ This plugin enables automatic code formatting on save by default using
 let g:zig_fmt_autosave = 0
 ```
 
+Additionally, `zig ast-check` is run after formatting, to disable this,
+set the following:
+
+```
+let g:zig_ast_check_autosave = 0
+```
+
+The above `zig fmt` and `zig ast-check` are done in separate steps, to do them
+in one step (as `zig fmt --ast-check`) set the following:
+
+```
+let g:zig_fmt_ast_check_autosave = 1
+```
+
 The default compiler which gets used by `:make` (`:help :compiler` for details)
 is `zig_build` and it runs `zig build`.  The other options are:
  * `:compiler zig_test` which runs `zig test` on the current file.

--- a/autoload/zig/fmt.vim
+++ b/autoload/zig/fmt.vim
@@ -4,7 +4,7 @@
 " Use of this source code is governed by a BSD-style
 " license that can be found in the LICENSE file.
 
-function! zig#fmt#Format() abort
+function! zig#fmt#Format(do_astcheck) abort
   " Save cursor position and many other things.
   let view = winsaveview()
 
@@ -13,7 +13,10 @@ function! zig#fmt#Format() abort
     return
   endif
 
-  let cmdline = 'zig fmt --stdin --ast-check'
+  let cmdline = 'zig fmt --stdin'
+  if a:do_astcheck
+    let cmdline .= ' --ast-check'
+  endif
   let current_buf = bufnr('')
 
   " The formatted code is output on stdout, the errors go on stderr.
@@ -75,6 +78,38 @@ function! zig#fmt#Format() abort
   " Run the syntax highlighter on the updated content and recompute the folds if
   " needed.
   syntax sync fromstart
+endfunction
+
+function! zig#fmt#Astcheck() abort
+  if !executable('zig')
+    echohl Error | echomsg "no zig binary found in PATH" | echohl None
+    return
+  endif
+
+  let cmdline = 'zig ast-check'
+  let current_buf = bufnr('')
+  if exists('*systemlist')
+    silent let out = systemlist(cmdline, current_buf)
+  else
+    silent let out = split(system(cmdline, current_buf))
+  endif
+  let err = v:shell_error
+
+  if err == 0
+    call setloclist(0, [], 'r')
+    lclose
+  else
+    let errors = s:parse_errors(expand('%'), out)
+
+    call setloclist(0, [], 'r', {
+        \ 'title': 'Errors',
+        \ 'items': errors,
+        \ })
+
+    let max_win_height = get(g:, 'zig_fmt_max_window_height', 5)
+    let win_height = min([max_win_height, len(errors)])
+    execute 'silent! lwindow ' . win_height
+  endif
 endfunction
 
 " parse_errors parses the given errors and returns a list of parsed errors

--- a/plugin/zig.vim
+++ b/plugin/zig.vim
@@ -3,15 +3,22 @@ if exists("g:zig_loaded")
 endif
 let g:zig_loaded = 1
 
-function! s:fmt_autosave()
-  if get(g:, "zig_fmt_autosave", 1)
-    call zig#fmt#Format()
+function! s:on_save()
+  if get(g:, "zig_fmt_ast_check_autosave", 0)
+    call zig#fmt#Format(v:true)
+  else
+    if get(g:, "zig_fmt_autosave", 1)
+      call zig#fmt#Format(v:false)
+    endif
+    if get(g:, "zig_ast_check_autosave", 1)
+      call zig#fmt#Astcheck()
+    endif
   endif
 endfunction
 
 augroup vim-zig
   autocmd!
-  autocmd BufWritePre *.zig call s:fmt_autosave()
+  autocmd BufWritePre *.zig call s:on_save()
 augroup end
 
 " vim: sw=2 ts=2 et


### PR DESCRIPTION
This splits up the ast check and formatting actions on save so that formatting can still run when there are simple errors like unused variables, but the errors still show up after formatting. Additionally this allows disabling one or the other (or both) through `g:zig_fmt_autosave`, `g:zig_ast_check_autosave`. To have the old behavior of running `zig fmt --ast-check` you can use `g:zig_fmt_ast_check_autosave = 1`