### PR TITLE
Use setfiletype instead of set filetype

### DIFF
--- a/ftdetect/zig.vim
+++ b/ftdetect/zig.vim
@@ -1,2 +1,2 @@
-au BufRead,BufNewFile *.zig set filetype=zig
-au BufRead,BufNewFile *.zir set filetype=zir
+au BufRead,BufNewFile *.zig setfiletype zig
+au BufRead,BufNewFile *.zir setfiletype zir


### PR DESCRIPTION
The :setfiletype command will not change the buffer's filetype if it is
already set, which prevents the FileType being set twice (which in turns
fires all FileType autocommands twice).
