### PR TITLE
Set b:undo_indent

### DIFF
--- a/indent/zig.vim
+++ b/indent/zig.vim
@@ -33,6 +33,8 @@ setlocal cinkeys=0{,0},0),0],!^F,o,O
 
 setlocal indentexpr=GetZigIndent(v:lnum)
 
+let b:undo_indent = "setlocal cindent< cinkeys< cinoptions< indentexpr<"
+
 function! GetZigIndent(lnum)
     let curretLineNum = a:lnum
     let currentLine = getline(a:lnum)


### PR DESCRIPTION
Like b:undo_ftplugin in filetype plugins, b:undo_indent should be set to
to a command that will undo the effect of any configuration changes in
indent plugins.

See :help undo_indent for details.
