### PR TITLE
Append g:zig_std_dir to &path

### DIFF
--- a/ftplugin/zig.vim
+++ b/ftplugin/zig.vim
@@ -44,7 +44,7 @@ if !exists('g:zig_std_dir') && exists('*json_decode') && executable('zig')
 endif
 
 if exists('g:zig_std_dir')
-    let &l:path = g:zig_std_dir . ',' . &l:path
+    let &l:path = &path . ',' . g:zig_std_dir
 endif
 
 let b:undo_ftplugin =


### PR DESCRIPTION
The current behaviour of the path option setting seems unintuitive to me: it ignores the global value of the path option, so any globally desired value of path (like the current directory/file) must be copied into the local local value in order files to be found anywhere outside the standard library. In particular this makes the default behaviour (i.e. if the user does not explicitly set a local value for `path` before the ftplugin is sourced) to not resolve files relative to the current file or directory (the default (global) value of `path` does this). This change uses `&path` instead of `&l:path` to fix this, making the default behaviour work as (I think should be) expected.

In addition, this change appends rather than prepends the standard library path - if a zig file does `@import("builtin.zig")` and there is a file `builtin.zig` in the same directory, then the file being imported is (barring some extreme use of `main-pkg-path`) that one, not the one in the standard library, so appending will make gf resolve it correctly with the default `path` option.