### PR TITLE
`g:zig_fmt_autoswitch`: Configure automatic switching to location list upon `zig fmt` error

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ This plugin enables automatic code formatting on save by default using
 let g:zig_fmt_autosave = 0
 ```
 
+If `zig fmt` encounters a code formatting error, this plugin populates
+the location list with relevant errors. To disable automatically switching
+to the location list, use this configuration in vimrc:
+
+```
+let g:zig_fmt_autoswitch = 0
+```
+
 The default compiler which gets used by `:make` (`:help :compiler` for details)
 is `zig_build` and it runs `zig build`.  The other options are:
  * `:compiler zig_test` which runs `zig test` on the current file.

--- a/autoload/zig/fmt.vim
+++ b/autoload/zig/fmt.vim
@@ -69,7 +69,12 @@ function! zig#fmt#Format() abort
 
   if err != 0
     echohl Error | echomsg "zig fmt returned error" | echohl None
-    return
+    if get(g:, 'zig_fmt_autoswitch', 1)
+      return
+    else
+      wincmd p
+      return
+    endif
   endif
 
   " Run the syntax highlighter on the updated content and recompute the folds if


### PR DESCRIPTION
Set `g:zig_fmt_autoswitch` to 0 in your vimrc to disable automatically switching to the location list if/when `zig fmt` encounters code formatting errors.

When set to 0, `g:zig_fmt_autoswitch` configures the Vim cursor to remain where it was prior to running `zig fmt`. The location list — which gets populated with code formatting errors as per normal — can then be viewed at a glance, without losing focus.

Either don’t set `g:zig_fmt_autoswitch` at all, or set it to 1, to keep the current behaviour of this plugin.