### PR TITLE
Remove incorrect comment in comments

### DIFF
--- a/ftplugin/zig.vim
+++ b/ftplugin/zig.vim
@@ -24,7 +24,7 @@ setlocal formatoptions-=t formatoptions+=croql
 setlocal suffixesadd=.zig,.zir
 
 if has('comments')
-    setlocal comments=:///,://!,://,:\\\\
+    setlocal comments=:///,://!,://
     setlocal commentstring=//\ %s
 endif
 


### PR DESCRIPTION
Remove the incorrect comment "\\" when setting comments in ftplugin/zig.vim.

"\\" is used for multiline string literals.

Closes #74