### PR TITLE
Remove wrongful escape characters from zig.vim compiler

### DIFF
--- a/compiler/zig.vim
+++ b/compiler/zig.vim
@@ -16,9 +16,9 @@ endif
 
 " a subcommand must be provided for the this compiler (test, build-exe, etc)
 if has('patch-7.4.191')
-    CompilerSet makeprg=zig\ \$*\ \%:S
+    CompilerSet makeprg=zig\ $*\ %:S
 else
-    CompilerSet makeprg=zig\ \$*\ \"%\"
+    CompilerSet makeprg=zig\ $*\ \"%\"
 endif
 
 " TODO: improve errorformat as needed.


### PR DESCRIPTION
$ and % shouldn't be escaped on the makeprg string and will result in error when trying to run this comp.