### PR TITLE
fix escape characters being forcefully inserted when calling 'zig env'

### DIFF
--- a/ftplugin/zig.vim
+++ b/ftplugin/zig.vim
@@ -44,8 +44,7 @@ if !exists('g:zig_std_dir') && exists('*json_decode') && executable('zig')
     try
         let g:zig_std_dir = json_decode(s:env)['std_dir']
     catch
-        echom "Error parsing Zig env output: " . v:exception
-        echom "Cleaned output: " . s:env
+        echom "Error parsing zig env output: " . v:exception
     endtry
     unlet! s:env
 endif


### PR DESCRIPTION
Fixes: https://github.com/ziglang/zig.vim/issues/105

This removes escape characters being inserted due to various shells configurations. I think the `-- plain` can technically be dropped, as escape characters for color rendering are inserted regardless.

I also tried solutions with:
- `--color off` (it led me to realize it was shell related)
- forcing a clean `env` during this scope (but I think it'd run into cross-platform issues)
- adding version checking as `--plain` was introduced in ~0.11, but I don't believe it is needed in the end.


cc: @melenaus 



