### PR TITLE
update syntax highlighting to more closely match existing languages

### DIFF
--- a/syntax/zig.vim
+++ b/syntax/zig.vim
@@ -86,7 +86,7 @@ highlight default link zigEscape Special
 highlight default link zigEscapeUnicode zigEscape
 highlight default link zigEscapeError Error
 highlight default link zigBoolean Boolean
-highlight default link zigNull Boolean
+highlight default link zigNull Constant
 highlight default link zigConstant Constant
 highlight default link zigNumber Number
 highlight default link zigArrowCharacter zigOperator


### PR DESCRIPTION
The current syntax highlighting that is provided for various keywords is in complete disconnect from any conventions established by syntax highlighting configurations from other languages. Here are some examples:

- `var`, `const`, `comptime` and `threadlocal` are mapped to the "Function" highlighting group by default
- `defer`, `errdefer` and `extern` are mapped to the "Macro" highlighting group by default
-  `volatile`, `linksection` and `allowzero` are mapped to the "Type" highlighting group by default
-  `return`, `break` and `continue` are mapped to the "Special" highlighting group by default

Having looked at the syntax highlighting of languages like C, C#, Rust, JavaScript, Java and Go, I haven't found a single languages with as many unusual choices as this plugin. My guess is that this syntax highlighting has been developed with some kind of flawed methodology of choosing whatever gives the desired highlighting on some specific colorscheme. 

Syntax highlighting configurations and colorschemes do not existing in isolation. We should try our best to match existing configuration of other languages and only deviate from them if we have a good reason for doing so. I ended up changing the configuration for many different keywords. The reasoning for these changes is explained in the individual commit messages. 

Here is how these changes affect some popular colorschemes:

<details>

<summary>Show Images</summary>

| Before       | After         |
| :----------: | :-----------: |
| folke/tokyonight.nvim   | folke/tokyonight.nvim    |
| ![neovim-tokyonight-old](https://github.com/user-attachments/assets/d911baa1-c7ce-4672-99e3-e18a2f890303) | ![neovim-tokyonight-new](https://github.com/user-attachments/assets/f394a32b-7a2b-4c64-858c-5fb0c484b05d) |
| morhetz/gruvbox   | morhetz/gruvbox    |
| ![neovim-gruvbox-old](https://github.com/user-attachments/assets/a3dc74b6-2967-452e-9bbb-3321990748c0) | ![neovim-gruvbox-new](https://github.com/user-attachments/assets/787bc32f-78a4-462a-a45f-58f6882fc171) |
| catppuccin/catppuccin   | catppuccin/catppuccin    |
| ![neovim-catppuccin-old](https://github.com/user-attachments/assets/1f317056-89bf-4711-a257-e8deb560d851) | ![neovim-catppuccin-new](https://github.com/user-attachments/assets/1e96faad-2f08-4e5d-90b5-aa0d0e16ee0a) |
| navarasu/onedark.nvim   | navarasu/onedark.nvim    |
| ![neovim-onedark-old](https://github.com/user-attachments/assets/cfc318e2-ce4d-4e29-865f-0a993b917256) | ![neovim-onedark-new](https://github.com/user-attachments/assets/793896f9-632a-48ca-81f3-0a9b2ef3ebd1) |
| Neovim's "vim" colorscheme | Neovim's "vim" colorscheme |
| ![neovim-vim-old](https://github.com/user-attachments/assets/a820c9de-213b-4ae9-84e7-ac17da878b5b) | ![neovim-vim-new](https://github.com/user-attachments/assets/72a21379-b07c-44ec-9b70-1fec07f4158c) |

```zig
const some_const: type = anyframe;
extern var some_var: u32;

pub const some_pub: []const u8 = "hello\\nworld!";
threadlocal var another_var: [*]allowzero align(8) u8 = undefined;

/// Some comment
const SomeStruct = packed struct {
    foo: u32,
    usingnamespace SomeStruct;
    fn copy(self: @This()) SomeStruct {
        return self;
    }
};

fn func(some: anytype) error{OutOfBrain}!void {
    var foo: u32 = 5;
    blk: while (some != 5) : (foo += 2) {
        if (1 != 2 or 2 != 1) {
            break;
        } else {
            continue :blk;
        }
    }
    errdefer comptime unreachable;
    return {};
}

test func {
    const result: SomeStruct = await func() catch unreachable;
    defer _ = result.copy();
    nosuspend {
        @import("std").debug.print("Hello {s}\\n", .{"World"});
    }
    return error.SkipZigTest;
}

pub export fn fanc(comptime T: type) callconv(.c) *anyopaque {
    inline for (0..5) |i| {
        switch (i) {
            .bar => |params| try T.member(params) orelse return,
            else => {},
        }
    }
}

noinline fn syscall1(noalias number: usize, arg1: usize) usize {
    return asm volatile ("syscall"
        : [ret] "={rax}" (-> usize),
        : [number] "{rax}" (number),
          [arg1] "{rdi}" (arg1),
        : "rcx", "r11"
    );
}
```

</details>

